### PR TITLE
Fix for advertised_prefix_count metric always equal to 0 in dashboards

### DIFF
--- a/pkg/gobgp_exporter/collect_peers.go
+++ b/pkg/gobgp_exporter/collect_peers.go
@@ -28,7 +28,7 @@ import (
 // GetPeers collects information about BGP peers.
 func (n *RouterNode) GetPeers() {
 
-	serverResponse, err := n.client.ListPeer(context.Background(), &gobgpapi.ListPeerRequest{})
+	serverResponse, err := n.client.ListPeer(context.Background(), &gobgpapi.ListPeerRequest{EnableAdvertised: true})
 	if err != nil {
 		level.Error(n.logger).Log(
 			"msg", "GoBGP query for peers failed",


### PR DESCRIPTION
For some reason the gobgpapi only exposes actual Afistate.Advertised number of routes if the request specifies EnableAdvertised. It wasn't done before so that's why the metric was always equal to 0. 

After the fix it correctly gets the info, example:
```
root@rs1001:/# curl localhost:9474/metrics | grep advertised_prefix_count | head -n5
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 45401    0 45401    0     0  10.8M      0 --:--:-- --:--:-- --:--:-- 10.8M
# HELP gobgp_peer_advertised_prefix_count Afistate.Advertised
# TYPE gobgp_peer_advertised_prefix_count gauge
gobgp_peer_advertised_prefix_count{address_family="afi_ip",name="<hidden>"} 4
gobgp_peer_advertised_prefix_count{address_family="afi_ip",name="<hidden>"} 4
gobgp_peer_advertised_prefix_count{address_family="afi_ip",name="<hidden>"} 4
```