### PR TITLE
add hostname metric

### DIFF
--- a/pkg/gobgp_exporter/collect.go
+++ b/pkg/gobgp_exporter/collect.go
@@ -15,6 +15,7 @@
 package exporter
 
 import (
+	"os"
 	"sync"
 	"time"
 
@@ -78,7 +79,14 @@ func (n *RouterNode) GatherMetrics() {
 		prometheus.GaugeValue,
 		float64(upValue),
 	))
-
+	if hostname, err := os.Hostname(); err == nil {
+		n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
+			routerHostname,
+			prometheus.GaugeValue,
+			1,
+			hostname,
+		))
+	}
 	n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 		routerErrors,
 		prometheus.CounterValue,

--- a/pkg/gobgp_exporter/describe.go
+++ b/pkg/gobgp_exporter/describe.go
@@ -23,6 +23,7 @@ import (
 func (n *RouterNode) Describe(ch chan<- *prometheus.Desc) {
 	ch <- routerUp
 	ch <- routerID
+	ch <- routerHostname
 	ch <- routerLocalAS
 	ch <- routerErrors
 	ch <- routerNextScrape

--- a/pkg/gobgp_exporter/describe_node.go
+++ b/pkg/gobgp_exporter/describe_node.go
@@ -24,6 +24,11 @@ var (
 		"Is GoBGP up and responds to queries (1) or is it down (0).",
 		nil, nil,
 	)
+	routerHostname = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "router", "hostname_info"),
+		"The hostname on which gobgp is running reported by OS kernel.",
+		[]string{"hostname"}, nil,
+	)
 	routerID = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "router", "id"),
 		"What is GoBGP router ID.",


### PR DESCRIPTION
Hostname is from `hostname, err := os.Hostname()`. On error no metric is sent.

Resulting metrics:
```
# HELP gobgp_router_hostname The hostname on which gobgp is running reported by OS kernel.
# TYPE gobgp_router_hostname gauge
gobgp_router_hostname_info{hostname="my-computer"} 1
```