### PR TITLE
Revert "Merge pull request #1 from piotrsuchy/fix_advertised_prefix_c…

### DIFF
--- a/pkg/gobgp_exporter/collect_peers.go
+++ b/pkg/gobgp_exporter/collect_peers.go
@@ -27,7 +27,7 @@ import (
 // GetPeers collects information about BGP peers.
 func (n *RouterNode) GetPeers() {
 
-	serverResponse, err := n.client.ListPeer(context.Background(), &gobgpapi.ListPeerRequest{EnableAdvertised: true})
+	serverResponse, err := n.client.ListPeer(context.Background(), &gobgpapi.ListPeerRequest{})
 	if err != nil {
 		n.logger.Errorf("msg: GoBGP query for peers failed. error: %s", err.Error())
 		n.IncrementErrorCounter()


### PR DESCRIPTION
…ount_0"

This reverts commit 7901f91af17c4a741b4b220b8b43d5e0fb2a26d9, reversing changes made to c655913004b865b86d6260343b76c2fca5aee07e.

This is done because ListPeer with enableAdvertised for a big-scale DC takes way too long and is CPU intensive.